### PR TITLE
Use ProctorU fork for stable builds

### DIFF
--- a/tensorflow_cc/cmake/TensorflowBase.cmake
+++ b/tensorflow_cc/cmake/TensorflowBase.cmake
@@ -7,7 +7,7 @@ set(FIXED_PROTOBUF "https://github.com/protocolbuffers/protobuf/releases/downloa
 
 ExternalProject_Add(
   tensorflow_base
-  GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
+  GIT_REPOSITORY https://github.com/proctoru/tensorflow.git
   GIT_TAG "${TENSORFLOW_TAG}"
   TMP_DIR "/tmp"
   STAMP_DIR "tensorflow-stamp"


### PR DESCRIPTION
The public tensorflow project has an unreliable url where it tries to
download eigen. Our fork removes the flaky url and always uses the
mirror instead.